### PR TITLE
[Dubbo-issue655] Fix issue655 upgrade Jetty to version 9.x 

### DIFF
--- a/dubbo-samples-docker/pom.xml
+++ b/dubbo-samples-docker/pom.xml
@@ -68,9 +68,14 @@
             <version>2.5</version>
         </dependency>
         <dependency>
-            <groupId>org.mortbay.jetty</groupId>
-            <artifactId>jetty</artifactId>
-            <version>6.1.26</version>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>9.4.11.v20180605</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>9.4.11.v20180605</version>
         </dependency>
 
         <dependency>

--- a/dubbo-samples-jetty/pom.xml
+++ b/dubbo-samples-jetty/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.alibaba</groupId>
+  <artifactId>dubbo-samples-jetty</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>dubbo-samples-jetty</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <parent>
+    <artifactId>dubbo-samples-all</artifactId>
+    <groupId>com.alibaba</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>9.4.11.v20180605</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>9.4.11.v20180605</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+        <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.7.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.20.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/dubbo-samples-jetty/pom.xml
+++ b/dubbo-samples-jetty/pom.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
+/*
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/HelloWorld.java
+++ b/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/HelloWorld.java
@@ -1,0 +1,28 @@
+package com.alibaba.dubbo.samples.jetty;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+
+import java.io.IOException;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+/**
+ * use a simple HelloWorld handler to run the server
+ */
+public class HelloWorld extends AbstractHandler
+{
+    public void handle(String target,
+                       Request baseRequest,
+                       HttpServletRequest request,
+                       HttpServletResponse response)
+            throws IOException, ServletException
+    {
+        response.setContentType("text/html;charset=utf-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        baseRequest.setHandled(true);
+        response.getWriter().println("<h1>Hello World</h1>");
+    }
+}

--- a/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/HelloWorld.java
+++ b/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/HelloWorld.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
 package com.alibaba.dubbo.samples.jetty;
 
 import javax.servlet.http.HttpServletRequest;

--- a/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/JettyContainer.java
+++ b/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/JettyContainer.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
 package com.alibaba.dubbo.samples.jetty;
 
 import com.alibaba.dubbo.common.logger.Logger;

--- a/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/JettyContainer.java
+++ b/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/JettyContainer.java
@@ -1,0 +1,42 @@
+package com.alibaba.dubbo.samples.jetty;
+
+import com.alibaba.dubbo.common.logger.Logger;
+import com.alibaba.dubbo.common.logger.LoggerFactory;
+import com.alibaba.dubbo.container.Container;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+
+/**
+ * Dubbo Container Extension, used to customize the load content.
+ */
+public class JettyContainer implements Container {
+
+    private static final Logger logger = LoggerFactory.getLogger(JettyContainer.class);
+
+    private static Server server = new Server(8080);
+
+    public void setServerHandler(Handler handler){
+        server.setHandler(handler);
+    }
+
+    @Override
+    public void start() {
+        try {
+            server.start();
+            server.join();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to start jetty" + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            try {
+                server.stop();
+            } catch (Exception e) {
+                logger.warn(e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/api/JettyService.java
+++ b/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/api/JettyService.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
 package com.alibaba.dubbo.samples.jetty.api;
 
 public interface JettyService {

--- a/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/api/JettyService.java
+++ b/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/api/JettyService.java
@@ -1,0 +1,5 @@
+package com.alibaba.dubbo.samples.jetty.api;
+
+public interface JettyService {
+    void sayHello();
+}

--- a/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/impl/JettyServiceImpl.java
+++ b/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/impl/JettyServiceImpl.java
@@ -1,0 +1,20 @@
+package com.alibaba.dubbo.samples.jetty.impl;
+
+import com.alibaba.dubbo.samples.jetty.HelloWorld;
+import com.alibaba.dubbo.samples.jetty.JettyContainer;
+import com.alibaba.dubbo.samples.jetty.api.JettyService;
+
+public class JettyServiceImpl implements JettyService {
+
+    private static JettyContainer container = new JettyContainer();
+
+    @Override
+    public void sayHello() {
+        container.setServerHandler(new HelloWorld());
+
+        container.start();
+
+        container.stop();
+    }
+
+}

--- a/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/impl/JettyServiceImpl.java
+++ b/dubbo-samples-jetty/src/main/java/com/alibaba/dubbo/samples/jetty/impl/JettyServiceImpl.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
 package com.alibaba.dubbo.samples.jetty.impl;
 
 import com.alibaba.dubbo.samples.jetty.HelloWorld;


### PR DESCRIPTION
## What is the purpose of the change

fix issue 655
https://github.com/apache/incubator-dubbo/issues/655

## Brief changelog

jetty upgrade to version 9.x and add a dubbo jetty demo  

## Verifying this change

see new add module dubbo-samples-jetty

From Baiji, Term 268, Team3, Problem 3-1