### PR TITLE
[Dubbo-1054][Baiji-9] add "send consumer application name to provider " feature #1054 

### DIFF
--- a/dubbo-samples-attachment/src/main/java/com/alibaba/dubbo/samples/attachment/AttachmentConsumer.java
+++ b/dubbo-samples-attachment/src/main/java/com/alibaba/dubbo/samples/attachment/AttachmentConsumer.java
@@ -28,11 +28,10 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 public class AttachmentConsumer {
 
     public static void main(String[] args) {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(new String[]{"spring/attachment-consumer.xml"});
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(new String[]{"META-INF/spring/attachment-consumer.xml"});
         context.start();
         AttachmentService attachmentService = (AttachmentService) context.getBean("demoService"); // get remote service proxy
 
-        RpcContext.getContext().setAttachment("index", "1");
         String hello = attachmentService.sayHello("world");
         System.out.println(hello); // get result
 

--- a/dubbo-samples-attachment/src/main/java/com/alibaba/dubbo/samples/attachment/filter/SendConsumerApplicationNameFilter.java
+++ b/dubbo-samples-attachment/src/main/java/com/alibaba/dubbo/samples/attachment/filter/SendConsumerApplicationNameFilter.java
@@ -17,19 +17,22 @@
  *
  */
 
-package com.alibaba.dubbo.samples.attachment;
+package com.alibaba.dubbo.samples.attachment.filter;
 
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.extension.Activate;
+import com.alibaba.dubbo.rpc.*;
 
+@Activate(group = Constants.CONSUMER)
+public class SendConsumerApplicationNameFilter implements Filter {
+    public static final String SEND_CONSUMER_APPLICATION_NAME_KEY = "sendConsumerApplicationName";
 
-public class AttachmentProvider {
-
-    public static void main(String[] args) throws Exception{
-        new EmbeddedZooKeeper(2181, false).start();
-        System.setProperty("java.net.preferIPv4Stack", "true");
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(new String[]{"META-INF/spring/attachment-provider.xml"});
-        context.start();
-
-        System.in.read(); // press any key to exit
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
+        if (invocation instanceof RpcInvocation) {
+            String consumerApplicationName = invoker.getUrl().getParameter(Constants.APPLICATION_KEY);
+            ((RpcInvocation) invocation).setAttachment(SEND_CONSUMER_APPLICATION_NAME_KEY, consumerApplicationName);
+        }
+        return invoker.invoke(invocation);
     }
 }

--- a/dubbo-samples-attachment/src/main/java/com/alibaba/dubbo/samples/attachment/impl/AttachmentImpl.java
+++ b/dubbo-samples-attachment/src/main/java/com/alibaba/dubbo/samples/attachment/impl/AttachmentImpl.java
@@ -24,14 +24,15 @@ import java.util.Date;
 
 import com.alibaba.dubbo.rpc.RpcContext;
 import com.alibaba.dubbo.samples.attachment.api.AttachmentService;
+import com.alibaba.dubbo.samples.attachment.filter.SendConsumerApplicationNameFilter;
 
 
 public class AttachmentImpl implements AttachmentService{
 
     public String sayHello(String name) {
 
-        String index = RpcContext.getContext().getAttachment("index");  //the attachment will be remove after this
-        System.out.println("receive attachment index: " + index);
+        String consumerApplicationName = RpcContext.getContext().getAttachment(SendConsumerApplicationNameFilter.SEND_CONSUMER_APPLICATION_NAME_KEY);  //the attachment will be remove after this
+        System.out.println("receive consumer application name: " + consumerApplicationName);
 
         System.out.println("[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "] Hello " + name + ", request from consumer: " + RpcContext
             .getContext().getRemoteAddress());

--- a/dubbo-samples-attachment/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.rpc.Filter
+++ b/dubbo-samples-attachment/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.rpc.Filter
@@ -1,0 +1,1 @@
+sendConsumerApplicationName=com.alibaba.dubbo.samples.attachment.filter.SendConsumerApplicationNameFilter

--- a/dubbo-samples-attachment/src/main/resources/META-INF/spring/attachment-consumer.xml
+++ b/dubbo-samples-attachment/src/main/resources/META-INF/spring/attachment-consumer.xml
@@ -33,7 +33,7 @@
 
     <!-- generate proxy for the remote service, then demoService can be used in the same way as the
     local regular interface -->
-    <dubbo:reference id="demoService" check="false" interface="com.alibaba.dubbo.samples.attachment.api.AttachmentService"/>
+    <dubbo:reference id="demoService" check="false" interface="com.alibaba.dubbo.samples.attachment.api.AttachmentService" filter="sendConsumerApplicationName"/>
 
 </beans>
 


### PR DESCRIPTION
## What is the purpose of the change

resolve the issue -- Provider cannot get the application parameter of consumer's url [#1054](https://github.com/apache/incubator-dubbo/issues/1054)

## Brief changelog

Add an internal filter to add consumer application name to Invocation attachements.In the provider endpoint,use RpcContext to get consumer application name.

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).